### PR TITLE
feat: add support for unix socket

### DIFF
--- a/lib/conn.c
+++ b/lib/conn.c
@@ -37,10 +37,9 @@ bool conn_init(conn_t *conn, char *addr_str, int port)
         return false;
 
     struct in_addr addr_ip;
-    int is_inet_addr = inet_aton(addr_str, &addr_ip);
-    if (is_inet_addr == 1) {
+    if (inet_aton(addr_str, &addr_ip) == 1) {
         if (!port) {
-            warn("Wrong port.\n");
+            warn("Missing port.\n");
             return false;
         }
         struct sockaddr_in addr;

--- a/lib/conn.c
+++ b/lib/conn.c
@@ -37,11 +37,7 @@ bool conn_init(conn_t *conn, char *addr_str, int port)
         return false;
 
     struct in_addr addr_ip;
-    if (inet_aton(addr_str, &addr_ip) == 1) {
-        if (!port) {
-            warn("Missing port.\n");
-            return false;
-        }
+    if (inet_aton(addr_str, &addr_ip) != 0) {
         struct sockaddr_in addr;
         addr.sin_family = AF_INET;
         addr.sin_addr.s_addr = addr_ip.s_addr;

--- a/lib/gdbstub.c
+++ b/lib/gdbstub.c
@@ -67,18 +67,20 @@ bool gdbstub_init(gdbstub_t *gdbstub,
     // This is a naive implementation to parse the string
     char *addr_str = strdup(s);
     char *port_str = strchr(addr_str, ':');
-    if (addr_str == NULL || port_str == NULL) {
+    int port = 0;
+    if (addr_str == NULL) {
         free(addr_str);
         return false;
     }
 
-    *port_str = '\0';
-    port_str += 1;
+    if (port_str != NULL) {
+        *port_str = '\0';
+        port_str += 1;
 
-    int port;
-    if (sscanf(port_str, "%d", &port) <= 0) {
-        free(addr_str);
-        return false;
+        if (sscanf(port_str, "%d", &port) <= 0) {
+            free(addr_str);
+            return false;
+        }
     }
 
     if (!conn_init(&gdbstub->priv->conn, addr_str, port)) {


### PR DESCRIPTION
Add support for Unix sockets to enable listening addresses like /tmp/gdbstub.sock. This significantly reduces communication costs and generally improves performance.