### PR TITLE
feat: add support for custom Target Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ following field within `arch_info_t` while integrating into your emulator:
 * `reg_num`: Number of target's registers
 
 The `target_desc` is an optional member which could be
-`TARGET_RV32` or `TARGET_RV64` if the emulator is RISC-V 32-bit or 64-t instruction set architecture,
-otherwise you would simply set it to `NULL`.
+`TARGET_RV32` or `TARGET_RV64` if the emulator is RISC-V 32-bit or 64-t instruction set architecture.
+Alternatively, it can be a custom Target Description document string used by gdb. 
+If none of these apply, simply set it to NULL.
+
 * Although the value of `reg_num` and `reg_byte` may be determined by `target_desc`, those
 members are still required to be filled correctly.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ following field within `arch_info_t` while integrating into your emulator:
 
 The `target_desc` is an optional member which could be
 `TARGET_RV32` or `TARGET_RV64` if the emulator is RISC-V 32-bit or 64-t instruction set architecture.
-Alternatively, it can be a custom Target Description document string used by gdb. 
+Alternatively, it can be a custom target description document string used by gdb. 
 If none of these apply, simply set it to NULL.
 
 * Although the value of `reg_num` and `reg_byte` may be determined by `target_desc`, those

--- a/include/conn.h
+++ b/include/conn.h
@@ -6,6 +6,7 @@
 #include "packet.h"
 
 #define MAX_SEND_PACKET_SIZE (0x400)
+#define MAX_DATA_PAYLOAD ( MAX_SEND_PACKET_SIZE - (2 + CSUM_SIZE + 2))
 
 typedef struct {
     int listen_fd;

--- a/include/conn.h
+++ b/include/conn.h
@@ -6,7 +6,7 @@
 #include "packet.h"
 
 #define MAX_SEND_PACKET_SIZE (0x400)
-#define MAX_DATA_PAYLOAD ( MAX_SEND_PACKET_SIZE - (2 + CSUM_SIZE + 2))
+#define MAX_DATA_PAYLOAD (MAX_SEND_PACKET_SIZE - (2 + CSUM_SIZE + 2))
 
 typedef struct {
     int listen_fd;

--- a/include/gdbstub.h
+++ b/include/gdbstub.h
@@ -4,8 +4,10 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#define TARGET_RV32 "<target version=\"1.0\"><architecture>riscv:rv32</architecture></target>"
-#define TARGET_RV64 "<target version=\"1.0\"><architecture>riscv:rv64</architecture></target>"
+#define TARGET_RV32 \
+    "<target version=\"1.0\"><architecture>riscv:rv32</architecture></target>"
+#define TARGET_RV64 \
+    "<target version=\"1.0\"><architecture>riscv:rv64</architecture></target>"
 
 typedef enum {
     EVENT_NONE,

--- a/include/gdbstub.h
+++ b/include/gdbstub.h
@@ -4,8 +4,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#define TARGET_RV32 "riscv:rv32"
-#define TARGET_RV64 "riscv:rv64"
+#define TARGET_RV32 "<target version=\"1.0\"><architecture>riscv:rv32</architecture></target>"
+#define TARGET_RV64 "<target version=\"1.0\"><architecture>riscv:rv64</architecture></target>"
 
 typedef enum {
     EVENT_NONE,

--- a/lib/gdbstub.c
+++ b/lib/gdbstub.c
@@ -276,7 +276,7 @@ void process_xfer(gdbstub_t *gdbstub, char *s)
 #endif
     if (!strcmp(name, "features") && gdbstub->arch.target_desc != NULL) {
         /* check the args */
-        char *action =  strtok(args, ":");
+        char *action = strtok(args, ":");
         assert(strcmp(action, "read") == 0);
         char *annex = strtok(NULL, ":");
         assert(strcmp(annex, "target.xml") == 0);
@@ -286,11 +286,13 @@ void process_xfer(gdbstub_t *gdbstub, char *s)
         sscanf(strtok(NULL, ":"), "%x,%x", &offset, &length);
 
         int total_len = strlen(gdbstub->arch.target_desc);
-        int payload_length = MAX_DATA_PAYLOAD > length ? length : MAX_DATA_PAYLOAD; 
+        int payload_length =
+            MAX_DATA_PAYLOAD > length ? length : MAX_DATA_PAYLOAD;
 
         // Determine if the remaining data fits within the buffer
-        buf[0]=(total_len - offset < payload_length ) ? 'l' : 'm';
-        snprintf(buf + 1 ,payload_length ,"%s", gdbstub->arch.target_desc+offset);
+        buf[0] = (total_len - offset < payload_length) ? 'l' : 'm';
+        snprintf(buf + 1, payload_length, "%s",
+                 gdbstub->arch.target_desc + offset);
 
         conn_send_pktstr(&gdbstub->priv->conn, buf);
     } else {
@@ -316,8 +318,7 @@ static void process_query(gdbstub_t *gdbstub, char *payload, void *args)
             int cpuid = gdbstub->ops->get_cpu(args);
             sprintf(packet_str, "QC%04d", cpuid);
             conn_send_pktstr(&gdbstub->priv->conn, packet_str);
-        }
-        else
+        } else
             conn_send_pktstr(&gdbstub->priv->conn, "");
     } else if (!strcmp(name, "Supported")) {
         if (gdbstub->arch.target_desc != NULL)
@@ -345,8 +346,7 @@ static void process_query(gdbstub_t *gdbstub, char *payload, void *args)
 
         packet_str[0] = 'm';
         ptr = packet_str + 1;
-        for (int cpuid = 0; cpuid < smp; cpuid++)
-        {
+        for (int cpuid = 0; cpuid < smp; cpuid++) {
             sprintf(cpuid_str, "%04d,", cpuid);
             memcpy(ptr, cpuid_str, 5);
             ptr += 5;
@@ -455,9 +455,7 @@ static void process_set_break_points(gdbstub_t *gdbstub,
         SEND_EINVAL(gdbstub);
 }
 
-static void process_set_cpu(gdbstub_t *gdbstub,
-                            char *payload,
-                            void *args)
+static void process_set_cpu(gdbstub_t *gdbstub, char *payload, void *args)
 {
     int cpuid;
     /* We don't support deprecated Hc packet, GDB


### PR DESCRIPTION
This commit makes it possible to pass a custom Target Description to gdb.

BTW,  I've edited `process_xfer` function for support of splitting large data blocks for transmission. 