### PR TITLE
support for architectures with varaible registers size like x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Method         | Description
 `set_bp`       | Set type `type` breakpoint on the address specified by `addr`. Return true if we set the breakpoint successfully, otherwise return false.
 `del_bp`       | Delete type `type` breakpoint on the address specified by `addr`. Return true if we delete the breakpoint successfully, otherwise return false.
 `on_interrupt` | Do something when receiving interrupt from GDB client. This method will run concurrently with `cont`, so you should be careful if there're shared data between them. You will need a lock or something similar to avoid data race.
-`set_cpu`      | Set the debug target CPU to `cpuid`
-`get_cpu`      | Get the current debug target CPU `cpuid` as return value
+`set_cpu`      | Set the debug target CPU to `cpuid`.
+`get_cpu`      | Get the current debug target CPU `cpuid` as return value.
 
 ```cpp
 struct target_ops {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ make
 To use the library in your project, you should include the file `gdbstub.h` first.
 Then, you have to initialize the pre-allocated structure `gdbstub_t` with `gdbstub_init`.
 
-```cpp
+```c
 bool gdbstub_init(gdbstub_t *gdbstub, struct target_ops *ops, arch_info_t arch, char *s);
 ```
 
@@ -40,7 +40,7 @@ Method         | Description
 `set_cpu`      | Set the debug target CPU to `cpuid`.
 `get_cpu`      | Get the current debug target CPU `cpuid` as return value.
 
-```cpp
+```c
 struct target_ops {
     gdb_action_t (*cont)(void *args);
     gdb_action_t (*stepi)(void *args);
@@ -63,7 +63,7 @@ should be `gdb_action_t`. After performing the relevant operation, you should re
 to continue debugging; otherwise, return `ACT_SHUTDOWN` to finish debugging. The library
 typically uses `ACT_NONE` to take no action.
 
-```cpp
+```c
 typedef enum {
     ACT_NONE,
     ACT_RESUME,
@@ -74,7 +74,7 @@ typedef enum {
 For `set_bp` and `del_bp`, the type of breakpoint which should be set or deleted is described
 in the type `bp_type_t`. In fact, its value will always be `BP_SOFTWARE` currently.
 
-```cpp
+```c
 typedef enum {
     BP_SOFTWARE = 0,
 } bp_type_t;
@@ -93,7 +93,7 @@ string used by gdb. If none of these apply, simply set it to NULL.
 * Although the value of `reg_num` may be determined by `target_desc`, those
 members are still required to be filled correctly.
 
-```cpp
+```c
 typedef struct {
     char *target_desc;
     int smp;
@@ -104,14 +104,14 @@ typedef struct {
 After startup, we can use `gdbstub_run` to run the emulator as gdbstub. The `args`
 can be used to pass the argument to any function in `struct target_ops`.
 
-```cpp
+```c
 bool gdbstub_run(gdbstub_t *gdbstub, void *args);
 ```
 
 When exiting from `gdbstub_run`, `gdbstub_close` should be called to recycle the resource on
 the initialization.
 
-```cpp
+```c
 void gdbstub_close(gdbstub_t *gdbstub);
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Method         | Description
 ---------------|------------------
 `cont`         | Run the emulator until hitting breakpoint or exit.
 `stepi`        | Do one step on the emulator. You may define your own step for the emulator. For example, the common design is executing one instruction.
+`get_reg_rize` | Get the register size in bytes for the register specified by `regno` as a return value.
 `read_reg`     | Read the value of the register specified by `regno` to `*value`. Return zero if the operation success, otherwise return an errno for the corresponding error.
 `write_reg`    | Write value `value` to the register specified by `regno`. Return zero if the operation success, otherwise return an errno for the corresponding error.
 `read_mem`     | Read the memory according to the address specified by `addr` with size `len` to the buffer `*val`. Return zero if the operation success, otherwise return an errno for the corresponding error.
@@ -43,8 +44,9 @@ Method         | Description
 struct target_ops {
     gdb_action_t (*cont)(void *args);
     gdb_action_t (*stepi)(void *args);
-    int (*read_reg)(void *args, int regno, size_t *value);
-    int (*write_reg)(void *args, int regno, size_t value);
+    size_t (*get_reg_rize)(int regno);
+    int (*read_reg)(void *args, int regno, void *value);
+    int (*write_reg)(void *args, int regno, void* value);
     int (*read_mem)(void *args, size_t addr, size_t len, void *val);
     int (*write_mem)(void *args, size_t addr, size_t len, void *val);
     bool (*set_bp)(void *args, size_t addr, bp_type_t type);
@@ -81,15 +83,14 @@ typedef enum {
 Another structure you have to declare is `arch_info_t`. You must explicitly specify about the
 following field within `arch_info_t` while integrating into your emulator:
 * `smp`: Number of target's CPU
-* `reg_byte`: Register's size in bytes
 * `reg_num`: Number of target's registers
 
 The `target_desc` is an optional member which could be
-`TARGET_RV32` or `TARGET_RV64` if the emulator is RISC-V 32-bit or 64-bit instruction
-set architecture. Alternatively, it can be a custom target description document
+`TARGET_RV32`,  `TARGET_RV64` if the emulator is RISC-V 32-bit or 64-bit instruction
+set architecture or `TARGET_X86_64` if the emulator is x86_64 instruction set architecture. Alternatively, it can be a custom target description document
 string used by gdb. If none of these apply, simply set it to NULL.
 
-* Although the value of `reg_num` and `reg_byte` may be determined by `target_desc`, those
+* Although the value of `reg_num` may be determined by `target_desc`, those
 members are still required to be filled correctly.
 
 ```cpp
@@ -97,7 +98,6 @@ typedef struct {
     char *target_desc;
     int smp;
     int reg_num;
-    size_t reg_byte;
 } arch_info_t;
 ```
 

--- a/emu/src/emu.c
+++ b/emu/src/emu.c
@@ -112,7 +112,8 @@ static void free_mem(struct mem *m)
     free(m->mem);
 }
 
-static size_t emu_get_reg_rize(int regno __attribute__((unused))) {
+static size_t emu_get_reg_rize(int regno __attribute__((unused)))
+{
     return 4;
 }
 
@@ -255,7 +256,7 @@ int main(int argc, char *argv[])
     }
 
     if (!gdbstub_init(&emu.gdbstub, &emu_ops,
-                      (arch_info_t){
+                      (arch_info_t) {
                           .smp = 1,
                           .reg_num = 33,
                           .target_desc = TARGET_RV32,

--- a/emu/src/emu.c
+++ b/emu/src/emu.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -111,7 +112,11 @@ static void free_mem(struct mem *m)
     free(m->mem);
 }
 
-static int emu_read_reg(void *args, int regno, size_t *reg_value)
+static size_t emu_get_reg_rize(int regno __attribute__((unused))) {
+    return 4;
+}
+
+static int emu_read_reg(void *args, int regno, void *reg_value)
 {
     struct emu *emu = (struct emu *) args;
     if (regno > 32) {
@@ -119,14 +124,14 @@ static int emu_read_reg(void *args, int regno, size_t *reg_value)
     }
 
     if (regno == 32) {
-        *reg_value = emu->pc;
+        memcpy(reg_value, &emu->pc, 4);
     } else {
-        *reg_value = emu->x[regno];
+        memcpy(reg_value, &emu->x[regno], 4);
     }
     return 0;
 }
 
-static int emu_write_reg(void *args, int regno, size_t data)
+static int emu_write_reg(void *args, int regno, void *data)
 {
     struct emu *emu = (struct emu *) args;
 
@@ -135,9 +140,9 @@ static int emu_write_reg(void *args, int regno, size_t data)
     }
 
     if (regno == 32) {
-        emu->pc = data;
+        memcpy(&emu->pc, data, 4);
     } else {
-        emu->x[regno] = data;
+        memcpy(&emu->x[regno], data, 4);
     }
     return 0;
 }
@@ -224,6 +229,7 @@ static void emu_on_interrupt(void *args)
 }
 
 struct target_ops emu_ops = {
+    .get_reg_rize = emu_get_reg_rize,
     .read_reg = emu_read_reg,
     .write_reg = emu_write_reg,
     .read_mem = emu_read_mem,
@@ -252,7 +258,6 @@ int main(int argc, char *argv[])
                       (arch_info_t){
                           .smp = 1,
                           .reg_num = 33,
-                          .reg_byte = 4,
                           .target_desc = TARGET_RV32,
                       },
                       "127.0.0.1:1234")) {

--- a/include/conn.h
+++ b/include/conn.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include "packet.h"
 
-#define MAX_SEND_PACKET_SIZE (0x400)
+#define MAX_SEND_PACKET_SIZE (0x1000)
 #define MAX_DATA_PAYLOAD (MAX_SEND_PACKET_SIZE - (2 + CSUM_SIZE + 2))
 
 typedef struct {

--- a/include/gdbstub.h
+++ b/include/gdbstub.h
@@ -8,8 +8,9 @@
     "<target version=\"1.0\"><architecture>riscv:rv32</architecture></target>"
 #define TARGET_RV64 \
     "<target version=\"1.0\"><architecture>riscv:rv64</architecture></target>"
-    #define TARGET_X86_64 \
-    "<target version=\"1.0\"><architecture>i386:x86-64</architecture></target>"
+#define TARGET_X86_64 \
+    "<target "        \
+    "version=\"1.0\"><architecture>i386:x86-64</architecture></target>"
 
 typedef enum {
     EVENT_NONE,
@@ -33,7 +34,7 @@ struct target_ops {
     gdb_action_t (*stepi)(void *args);
     size_t (*get_reg_rize)(int regno);
     int (*read_reg)(void *args, int regno, void *value);
-    int (*write_reg)(void *args, int regno, void* value);
+    int (*write_reg)(void *args, int regno, void *value);
     int (*read_mem)(void *args, size_t addr, size_t len, void *val);
     int (*write_mem)(void *args, size_t addr, size_t len, void *val);
     bool (*set_bp)(void *args, size_t addr, bp_type_t type);

--- a/include/gdbstub.h
+++ b/include/gdbstub.h
@@ -8,6 +8,8 @@
     "<target version=\"1.0\"><architecture>riscv:rv32</architecture></target>"
 #define TARGET_RV64 \
     "<target version=\"1.0\"><architecture>riscv:rv64</architecture></target>"
+    #define TARGET_X86_64 \
+    "<target version=\"1.0\"><architecture>i386:x86-64</architecture></target>"
 
 typedef enum {
     EVENT_NONE,
@@ -29,8 +31,9 @@ typedef enum {
 struct target_ops {
     gdb_action_t (*cont)(void *args);
     gdb_action_t (*stepi)(void *args);
-    int (*read_reg)(void *args, int regno, size_t *value);
-    int (*write_reg)(void *args, int regno, size_t value);
+    size_t (*get_reg_rize)(int regno);
+    int (*read_reg)(void *args, int regno, void *value);
+    int (*write_reg)(void *args, int regno, void* value);
     int (*read_mem)(void *args, size_t addr, size_t len, void *val);
     int (*write_mem)(void *args, size_t addr, size_t len, void *val);
     bool (*set_bp)(void *args, size_t addr, bp_type_t type);
@@ -47,7 +50,6 @@ typedef struct {
     char *target_desc;
     int smp;
     int reg_num;
-    size_t reg_byte;
 } arch_info_t;
 
 typedef struct {

--- a/lib/gdbstub.c
+++ b/lib/gdbstub.c
@@ -182,7 +182,7 @@ static void process_reg_write_one(gdbstub_t *gdbstub, char *payload, void *args)
     size_t reg_sz = gdbstub->ops->get_reg_rize(regno);
     assert((data = malloc(reg_sz)) != NULL);
     assert(strlen(data_str) == reg_sz * 2);
-    
+
     str_to_hex(data_str, (uint8_t *) data, reg_sz);
 #ifdef DEBUG
     printf("reg write = regno %d / data %lx\n", regno, data);

--- a/lib/gdbstub.c
+++ b/lib/gdbstub.c
@@ -96,60 +96,107 @@ bool gdbstub_init(gdbstub_t *gdbstub,
 #define SEND_EPERM(gdbstub) SEND_ERR(gdbstub, "E01")
 #define SEND_EINVAL(gdbstub) SEND_ERR(gdbstub, "E22")
 
+static void *get_register_buffer(size_t reg_sz,
+                                 size_t *local_buf,
+                                 int *malloc_used)
+{
+    *malloc_used = 0;
+    if (reg_sz <= sizeof(size_t)) {
+        /* Use stack memory for small registers */
+        return local_buf;
+    } else {
+        void *buf = malloc(reg_sz);
+        if (buf) {
+            *malloc_used = 1;
+        }
+        return buf;
+    }
+}
+
+static void free_register_buffer(void *buf, int malloc_used)
+{
+    if (malloc_used) {
+        free(buf);
+    }
+}
+
 static void process_reg_read(gdbstub_t *gdbstub, void *args)
 {
     char packet_str[MAX_SEND_PACKET_SIZE];
+    size_t local_buf;  // Stack variable for small registers
     void *reg_value = NULL;
+    int malloc_used = 0;
 
     for (int i = 0; i < gdbstub->arch.reg_num; i++) {
         size_t reg_sz = gdbstub->ops->get_reg_rize(i);
-        assert((reg_value = malloc(reg_sz)) != NULL);
+
+        // Free previous allocation if it exists
+        free_register_buffer(reg_value, malloc_used);
+        malloc_used = 0;
+
+        assert((reg_value = get_register_buffer(reg_sz, &local_buf,
+                                                &malloc_used)) != NULL);
+
         int ret = gdbstub->ops->read_reg(args, i, reg_value);
         if (!ret) {
             hex_to_str((uint8_t *) reg_value, &packet_str[i * reg_sz * 2],
                        reg_sz);
         } else {
             sprintf(packet_str, "E%d", ret);
-            free(reg_value);
             break;
         }
     }
+    free_register_buffer(reg_value, malloc_used);
+
     conn_send_pktstr(&gdbstub->priv->conn, packet_str);
-    free(reg_value);
 }
 
 static void process_reg_read_one(gdbstub_t *gdbstub, char *payload, void *args)
 {
     char packet_str[MAX_SEND_PACKET_SIZE];
     int regno;
-    void *reg_value;
+    size_t local_buf;  // Stack variable for small registers
+    void *reg_value = NULL;
+    int malloc_used = 0;
 
     assert(sscanf(payload, "%x", &regno) == 1);
     size_t reg_sz = gdbstub->ops->get_reg_rize(regno);
-    assert((reg_value = malloc(reg_sz)) != NULL);
+
+    assert((reg_value =
+                get_register_buffer(reg_sz, &local_buf, &malloc_used)) != NULL);
+
     int ret = gdbstub->ops->read_reg(args, regno, reg_value);
 #ifdef DEBUG
-    printf("reg read = regno %d data %lx\n", regno, reg_value);
+    printf("reg read = regno %d data %lx\n", regno, *(size_t *) reg_value);
 #endif
     if (!ret) {
         hex_to_str((uint8_t *) reg_value, packet_str, reg_sz);
     } else {
         sprintf(packet_str, "E%d", ret);
     }
+
+    free_register_buffer(reg_value, malloc_used);
     conn_send_pktstr(&gdbstub->priv->conn, packet_str);
-    free(reg_value);
 }
 
 static void process_reg_write(gdbstub_t *gdbstub, char *payload, void *args)
 {
+    size_t local_buf;  // Stack variable for small registers
     void *reg_value = NULL;
+    int malloc_used = 0;
 
     for (int i = 0; i < gdbstub->arch.reg_num; i++) {
+        // Free previous allocation if it exists
+        free_register_buffer(reg_value, malloc_used);
+        malloc_used = 0;
+
         size_t reg_sz = gdbstub->ops->get_reg_rize(i);
-        assert((reg_value = malloc(reg_sz)) != NULL);
+        assert((reg_value = get_register_buffer(reg_sz, &local_buf,
+                                                &malloc_used)) != NULL);
+
         str_to_hex(&payload[i * reg_sz * 2], (uint8_t *) reg_value, reg_sz);
 #ifdef DEBUG
-        printf("reg write = regno %d data %lx\n", i, reg_value);
+        printf("reg write = regno %d data %lx\n", i, *(size_t *) reg_value);
 #endif
         int ret = gdbstub->ops->write_reg(args, i, reg_value);
         if (ret) {
@@ -158,19 +205,22 @@ static void process_reg_write(gdbstub_t *gdbstub, char *payload, void *args)
              * an expected behavior. */
             char packet_str[MAX_SEND_PACKET_SIZE];
             sprintf(packet_str, "E%d", ret);
+            free_register_buffer(reg_value, malloc_used);
             conn_send_pktstr(&gdbstub->priv->conn, packet_str);
-            free(reg_value);
             return;
         }
     }
+
+    free_register_buffer(reg_value, malloc_used);
     conn_send_pktstr(&gdbstub->priv->conn, "OK");
-    free(reg_value);
 }
 
 static void process_reg_write_one(gdbstub_t *gdbstub, char *payload, void *args)
 {
     int regno;
-    void *data;
+    size_t local_buf;  // Stack variable for small registers
+    void *data = NULL;
+    int malloc_used = 0;
     char *regno_str = payload;
     char *data_str = strchr(payload, '=');
     if (data_str) {
@@ -180,14 +230,19 @@ static void process_reg_write_one(gdbstub_t *gdbstub, char *payload, void *args)
 
     assert(sscanf(regno_str, "%x", &regno) == 1);
     size_t reg_sz = gdbstub->ops->get_reg_rize(regno);
-    assert((data = malloc(reg_sz)) != NULL);
+
+    assert((data = get_register_buffer(reg_sz, &local_buf, &malloc_used)) !=
+           NULL);
     assert(strlen(data_str) == reg_sz * 2);
 
     str_to_hex(data_str, (uint8_t *) data, reg_sz);
 #ifdef DEBUG
-    printf("reg write = regno %d / data %lx\n", regno, data);
+    printf("reg write = regno %d / data %lx\n", regno, *(size_t *) data);
 #endif
     int ret = gdbstub->ops->write_reg(args, regno, data);
+
+    free_register_buffer(data, malloc_used);
+
     if (!ret) {
         conn_send_pktstr(&gdbstub->priv->conn, "OK");
     } else {
@@ -195,7 +250,6 @@ static void process_reg_write_one(gdbstub_t *gdbstub, char *payload, void *args)
         sprintf(packet_str, "E%d", ret);
         conn_send_pktstr(&gdbstub->priv->conn, packet_str);
     }
-    free(data);
 }
 
 static void process_mem_read(gdbstub_t *gdbstub, char *payload, void *args)

--- a/lib/gdbstub.c
+++ b/lib/gdbstub.c
@@ -138,6 +138,12 @@ static void process_reg_read(gdbstub_t *gdbstub, void *args)
                                                 &malloc_used)) != NULL);
 
         int ret = gdbstub->ops->read_reg(args, i, reg_value);
+#ifdef DEBUG
+        char debug_hex[MAX_SEND_PACKET_SIZE];
+        hex_to_str((uint8_t *) reg_value, debug_hex, reg_sz);
+        printf("reg read = regno %d data 0x%s (size %zu)\n", i, debug_hex,
+               reg_sz);
+#endif
         if (!ret) {
             hex_to_str((uint8_t *) reg_value, &packet_str[i * reg_sz * 2],
                        reg_sz);
@@ -167,7 +173,10 @@ static void process_reg_read_one(gdbstub_t *gdbstub, char *payload, void *args)
 
     int ret = gdbstub->ops->read_reg(args, regno, reg_value);
 #ifdef DEBUG
-    printf("reg read = regno %d data %lx\n", regno, *(size_t *) reg_value);
+    char debug_hex[MAX_SEND_PACKET_SIZE];
+    hex_to_str((uint8_t *) reg_value, debug_hex, reg_sz);
+    printf("reg read = regno %d data 0x%s (size %zu)\n", regno, debug_hex,
+           reg_sz);
 #endif
     if (!ret) {
         hex_to_str((uint8_t *) reg_value, packet_str, reg_sz);
@@ -196,7 +205,10 @@ static void process_reg_write(gdbstub_t *gdbstub, char *payload, void *args)
 
         str_to_hex(&payload[i * reg_sz * 2], (uint8_t *) reg_value, reg_sz);
 #ifdef DEBUG
-        printf("reg write = regno %d data %lx\n", i, *(size_t *) reg_value);
+        char debug_hex[MAX_SEND_PACKET_SIZE];
+        hex_to_str((uint8_t *) reg_value, debug_hex, reg_sz);
+        printf("reg write = regno %d data 0x%s (size %zu)\n", i, debug_hex,
+               reg_sz);
 #endif
         int ret = gdbstub->ops->write_reg(args, i, reg_value);
         if (ret) {
@@ -237,8 +249,10 @@ static void process_reg_write_one(gdbstub_t *gdbstub, char *payload, void *args)
 
     str_to_hex(data_str, (uint8_t *) data, reg_sz);
 #ifdef DEBUG
-    printf("reg write = regno %d / data %lx\n", regno, *(size_t *) data);
+    printf("reg write = regno %d data 0x%s (size %zu)\n", regno, data_str,
+           reg_sz);
 #endif
+
     int ret = gdbstub->ops->write_reg(args, regno, data);
 
     free_register_buffer(data, malloc_used);


### PR DESCRIPTION
i added this functionality maintaining compatibility with the previous version. if `reg_byte` is not `0` the library behave the same as before, if is `0`, the size of registers is retrieved from `regs_byte` array.